### PR TITLE
Fix asset key contains brackets

### DIFF
--- a/importers/CSVImporter.py
+++ b/importers/CSVImporter.py
@@ -470,7 +470,7 @@ def mapping_account(account_map, keyword):
     for account_keywords in account_map.keys():
         if account_keywords == "DEFAULT":
             continue
-        if re.search(account_keywords, keyword):
+        if re.search(account_keywords, keyword) or account_keywords == keyword:
             account_name = account_map[account_keywords]
             break
     return account_name


### PR DESCRIPTION
When the account name is contained in brackets, the result cannot be correctly matched.

This occurs when multiple bank cards from the same bank, e.g. 招商银行(1234)

```python
account_map = {
    "assets": {
        "DEFAULT": "Assets:Unknown",
        "招商银行(1234)": "Liabilities:CreditCard"
    }
}
```